### PR TITLE
Links to videos

### DIFF
--- a/Meetings.md
+++ b/Meetings.md
@@ -1,0 +1,9 @@
+# DM Stack Club Meetings
+
+Inidividual session recordings are linked below, or you can [browse the whole YouTube channel](https://www.youtube.com/playlist?list=PLSZI_WphK4J7EZyAbNTfiDsN2j0UjclRx).
+
+| Session  | Date  | Topic  | Links  |
+|---|---|---|---|
+| Phase 1, Session 1 | Friday May 25, 2018 [(video)](https://www.youtube.com/watch?v=UjB0aaNd0MA) | Visualization with Firefly  | [SQuaRE notebook](https://github.com/lsst-sqre/notebook-demo/blob/master/Firefly.ipynb) |
+|   |   |   |   |
+|   |   |   |   |

--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ the LSST Science Collaborations.
 | Visualization    | Displaying images and catalogs. | [DMStackClub/Visualization](Visualization)  |
 | Image Processing  | From raw images to `calexp`s and `coadd`s.  | [DMStackClub/ImageProcessing](ImageProcessing)  |
 
-## Contact
+## Contributing
+New Stack Club members: please see the [notes on getting started](GettingStarted/GettingStarted.md) - they'll walk you onto you new LSST Science Platform account, and show you how to work on your tutorial notebooks.
 
+Everyone else: we welcome pull requests! Feel free to fork this repo and send us a pull request. And if you are interested in joining the DM Stack Club, please drop one of us a line, or come and find us in the [#dm-stack-club](https://lsstc.slack.com/messages/C9YRAS4HM) LSSTC Slack channel.
+
+## Contact
 We welcome your input! Please post questions and suggestions in the
 [issues](https://github.com/LSSTScienceCollaborations/DMStackClub/issues) of this repository. You can also contact the following points of contact directly via the links below:
 
@@ -26,7 +30,7 @@ We welcome your input! Please post questions and suggestions in the
 * Alex Drlica-Wagner (Fermilab, [@kadrlica](https://github.com/LSSTScienceCollaborations/DMStackClub/issues/new?body=@kadrlica))
 * Phil Marshall (SLAC, [@drphilmarshall](https://github.com/LSSTScienceCollaborations/DMStackClub/issues/new?body=@drphilmarshall))
 
-The Club meets periodically via Zoom, but you can find us on LSSTC Slack at [#dm-stack-club](https://lsstc.slack.com/messages/C9YRAS4HM). You can also watch the tutorial walkthroughs in the Club sessions on the [DM Stack Club YouTube channel](https://www.youtube.com/playlist?list=PLSZI_WphK4J7EZyAbNTfiDsN2j0UjclRx).
+The Club meets periodically via Zoom, but you can find us on LSSTC Slack at [#dm-stack-club](https://lsstc.slack.com/messages/C9YRAS4HM). You can also watch the tutorial walkthroughs in the Club sessions on the [DM Stack Club YouTube channel](https://www.youtube.com/playlist?list=PLSZI_WphK4J7EZyAbNTfiDsN2j0UjclRx), and see what we talked about on the [Meetings page](Meetings.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ the LSST Science Collaborations.
 
 | Topic   | Description  | Notebook Location  |
 |---|---|---|
-| Getting Started  | Basics of using JupyterLab, and contributing to the DM Stack Club repo.  | DMStackClub/GettingStarted  |
-| Visualization    | Displaying images and catalogs.  | DMStackClub/Visualization  |
-|   |   |   |
+| Getting Started  | Basics of using JupyterLab, and contributing to the DM Stack Club repo.  | [DMStackClub/GettingStarted](GettingStarted)  |
+| Visualization    | Displaying images and catalogs. | [DMStackClub/Visualization](Visualization)  |
+| Image Processing  | From raw images to `calexp`s and `coadd`s.  | [DMStackClub/ImageProcessing](ImageProcessing)  |
 
 ## Contact
 
@@ -26,7 +26,7 @@ We welcome your input! Please post questions and suggestions in the
 * Alex Drlica-Wagner (Fermilab, [@kadrlica](https://github.com/LSSTScienceCollaborations/DMStackClub/issues/new?body=@kadrlica))
 * Phil Marshall (SLAC, [@drphilmarshall](https://github.com/LSSTScienceCollaborations/DMStackClub/issues/new?body=@drphilmarshall))
 
-The Club meets periodically via Zoom (or at least will do from late May 2018), but you can find us on LSSTC Slack at [#dm-stack-club](https://lsstc.slack.com/messages/C9YRAS4HM).
+The Club meets periodically via Zoom, but you can find us on LSSTC Slack at [#dm-stack-club](https://lsstc.slack.com/messages/C9YRAS4HM). You can also watch the tutorial walkthroughs in the Club sessions on the [DM Stack Club YouTube channel](https://www.youtube.com/playlist?list=PLSZI_WphK4J7EZyAbNTfiDsN2j0UjclRx).
 
 ## License
 

--- a/Visualization/README.md
+++ b/Visualization/README.md
@@ -3,3 +3,5 @@
 This folder contains:
 
 * Nothing, yet.
+
+However, you can find the SQuaRE team's Firefly tutorial notebook [here](https://github.com/lsst-sqre/notebook-demo/blob/master/Firefly.ipynb), and watch the Phase 1 Session 1 video (in which Alex walks us through it) [here](https://www.youtube.com/watch?v=UjB0aaNd0MA).


### PR DESCRIPTION
I think a link to our (new) YouTube channel (actually a playlist) on the main README, plus links in the folder READMEs where appropriate. I guess a separate page listing all the meetings might be good too.